### PR TITLE
Accept non-undefined falsey property values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,9 +118,9 @@ GeoJSON2SVG.prototype.convertFeature = function(feature,options) {
         try {
           val = valueAt(feature, property)
         } catch(e) {
-          val = false
+          val = undefined
         }
-        if (val) sum[key] = val
+        if (val !== undefined) sum[key] = val
       } else if (typeof(property) === 'object' && property.type
         && property.property)
       {
@@ -130,9 +130,9 @@ GeoJSON2SVG.prototype.convertFeature = function(feature,options) {
           try {
             val = valueAt(feature, property.property)
           } catch(e) {
-            val = false
+            val = undefined
           }
-          if (val) sum[key] = val
+          if (val !== undefined) sum[key] = val
         } else if (property.type === 'static'  && property.value) {
           sum[property.property] = property.value
         }

--- a/test/test.js
+++ b/test/test.js
@@ -194,6 +194,12 @@ describe('geojson2svg', function() {
             property: 'bar',
             value: 'barStatic',
             type: 'static'
+          }, {
+            property: 'properties.baz',
+            type: 'dynamic'
+          }, {
+            property: 'properties.qux',
+            type: 'dynamic'
           }]
       });
       var svgStr = converter.convert({
@@ -201,11 +207,11 @@ describe('geojson2svg', function() {
         features: [{
           type: 'Feature',
           geometry: {type: 'LineString', coordinates: [[0,0], [1000,1000]]},
-          properties: {foo: 'fooVal-1', bar: 'barVal-1', baz: 'bazVal-1'}
+          properties: {foo: 'fooVal-1', bar: 'barVal-1', baz: 'bazVal-1', qux: 0}
         }, {
           type: 'Feature',
           geometry: {type: 'LineString', coordinates: [[10,10], [100,100]]},
-          properties: {foo: 'fooVal-2', bar: 'barVal-2'}
+          properties: {foo: 'fooVal-2', bar: 'barVal-2', baz: false, qux: null}
         }]
       })
       var svgEle1 = string2dom(svgStr[0]);
@@ -213,13 +219,15 @@ describe('geojson2svg', function() {
       expect(svgEle1.getAttribute('id')).to.be.equal('fooVal-1');
       expect(svgEle1.getAttribute('bar')).to.be.equal('barStatic');
       expect(svgEle1.getAttribute('baz')).to.be.equal('bazVal-1');
+      expect(svgEle1.getAttribute('qux')).to.be.equal('0');
       expect(svgEle1.getAttribute('foo')).to.be.null;
 
       var svgEle2 = string2dom(svgStr[1]);
       expect(svgEle2).to.respondTo('getAttribute');
       expect(svgEle2.getAttribute('id')).to.be.equal('fooVal-2');
       expect(svgEle2.getAttribute('bar')).to.be.equal('barStatic');
-      expect(svgEle2.getAttribute('baz')).to.be.null;
+      expect(svgEle2.getAttribute('baz')).to.be.equal('false');
+      expect(svgEle2.getAttribute('qux')).to.be.equal('null');
       expect(svgEle2.getAttribute('foo')).to.be.null;
     });
 


### PR DESCRIPTION
I'm trying to map integer properties to SVG attributes. This PR changes the simple falsey check to an undefined check so that a `0` value is not treated as missing.

This also means accepting `""` as well as `null`. Everything comes out of the DOM as a string but at least the values aren't lost.